### PR TITLE
dynamic header row on player table

### DIFF
--- a/src/components/hockey/players/Players.vue
+++ b/src/components/hockey/players/Players.vue
@@ -59,7 +59,7 @@ export default {
             return this.allPlayers.map(player => ({
                 name: player.name,
                 games_played: 100,
-                team: 'Current Team',
+                team: player.season.at(0).team.team_name,
                 goals: 10,
                 assists: 50,
                 points: 60,

--- a/src/components/hockey/players/Players.vue
+++ b/src/components/hockey/players/Players.vue
@@ -58,11 +58,11 @@ export default {
         rows() {
             return this.allPlayers.map(player => ({
                 name: player.name,
-                games_played: 100,
+                games_played: player.season.reduce(function (acc, obj) { return acc + obj.games_played}, 0),
                 team: player.season.at(0).team.team_name,
-                goals: 10,
-                assists: 50,
-                points: 60,
+                goals: player.season.reduce(function (acc, obj) { return acc + obj.goals}, 0),
+                assists: player.season.reduce(function (acc, obj) { return acc + obj.assists}, 0),
+                points: player.season.reduce(function (acc, obj) { return acc + obj.points}, 0),
                 children: player.season.map(seas => ({
                     year: seas.year,
                     games_played: seas.games_played,


### PR DESCRIPTION
## What does this PR do?
This PR adds the sum of the player table fields to the header column 
## Related PRs
n/a
## Testing Steps
- navigate to http://localhost:8080/hockey/sets/year/2022 and select series 1
- see that the header cell is the sum of the numbers for that column
## Checklist before merging
- [ ] If its a core feature, I have added through test.
- [ ] Do we need to implement analytics? 
- [ ] Will this be part of a product update? If yes, please write one phrase about this update
