### PR TITLE
cleaned up nav and remove vue starter code

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,9 @@
 <template>
   <div id="app">
     <nav>
-      <router-link to="/">Home</router-link> |
-      <router-link to="/about">About</router-link> |
-      <router-link to="/hockey/sets/year">Sets</router-link> |
-      <router-link to="/hockey/players/addPlayers">Add Player</router-link>
+      <router-link to="/hockey/sets/year">Hockey</router-link> | Admin Links: 
+      <router-link to="/hockey/players/addPlayers">Add Player</router-link> |
+      <router-link to="/hockey/sets/addSets">Add Set</router-link>
     </nav>
     <router-view/>
   </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,26 +1,10 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-import HomeView from '../views/HomeView.vue'
 
 Vue.use(VueRouter)
 
 const routes = [
-  {
-    path: '/',
-    name: 'home',
-    component: HomeView
-  },
-  {
-    path: '/about',
-    name: 'about',
-    // route level code-splitting
-    // this generates a separate chunk (about.[hash].js) for this route
-    // which is lazy-loaded when the route is visited.
-    component: () => import(/* webpackChunkName: "about" */ '../views/AboutView.vue')
-  },
-
   // Sets Routes
-
   {
     path: '/hockey/sets/year',
     name: 'setsIndex',
@@ -40,7 +24,6 @@ const routes = [
   },
   
   // Player Routes
-
   { 
     path: '/hockey/players/addPlayers',
     name: 'addPlayer',
@@ -48,7 +31,6 @@ const routes = [
   },
 
   // Misc Routes
-
   {
     path: '*',
     name: '404',


### PR DESCRIPTION
## What does this PR do?
This PR removes vue starter code for home and about pages and updates nave with static admin links (because auth is not setup yet)
## Related PRs

## Testing Steps
- see that nav bar no longer has home and about links and that the home route (./) and about route (./about) 404's
## Checklist before merging
- [ ] If its a core feature, I have added through test.
- [ ] Do we need to implement analytics? 
- [ ] Will this be part of a product update? If yes, please write one phrase about this update
