### PR TITLE
team store for create and read setup, added addteam formand view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,8 @@
     <nav>
       <router-link to="/hockey/sets/year">Hockey</router-link> | Admin Links: 
       <router-link to="/hockey/players/addPlayers">Add Player</router-link> |
-      <router-link to="/hockey/sets/addSets">Add Set</router-link>
+      <router-link to="/hockey/sets/addSets">Add Set</router-link> |
+      <router-link to="/hockey/teams/addTeams">Add Team</router-link> |
     </nav>
     <router-view/>
   </div>

--- a/src/api/hockey.js
+++ b/src/api/hockey.js
@@ -19,7 +19,15 @@ export default {
     },
     storeSet(payload) {
         return axios.post('http://127.0.0.1:8000/api/sets', payload)
-    }
+    },
+
+    // Team API
+    getTeams() {
+        return axios.get('http://127.0.0.1:8000/api/teams')
+    },
+    storeTeam(payload) {
+        return axios.post('http://127.0.0.1:8000/api/teams', payload)
+    },
 }
 
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,6 +30,13 @@ const routes = [
     component: () => import(/* webpackChunkName: "about" */'../views/hockey/players/AddPlayer.vue')
   },
 
+  // Team Routes
+  { 
+    path: '/hockey/teams/addTeams',
+    name: 'addTeam',
+    component: () => import(/* webpackChunkName: "about" */'../views/hockey/teams/AddTeam.vue')
+  },
+
   // Misc Routes
   {
     path: '*',

--- a/src/store/hockey/index.js
+++ b/src/store/hockey/index.js
@@ -6,15 +6,19 @@ export default {
     state: {
         playerList: [],
         setList: [],
+        teamList: [],
         set: {},
         player: {},
+        team: {},
     },
 
     getters: {
         player: state => state.player,
         set: state => state.set,
+        team: state => state.team,
         allPlayers: state => state.playerList,
         allSets: state => state.setList,
+        allTeams: state => state.teamList,
     },
 
     mutations: {
@@ -37,6 +41,15 @@ export default {
             const set = { ...data }
             Vue.set(state, 'set', set)
         },
+        setTeamList(state, teams) {
+            Vue.set(state, 'teamList', teams)
+        },
+        setTeam(state, team) {
+            Vue.set(state, 'team', team)
+        },
+        storeTeam(state, team) {
+            state.teamList.push(team)
+        }
 
     },
 
@@ -88,11 +101,33 @@ export default {
                     commit('setSet', res.data)
                 })
         },
+        setTeamList({ commit }) {
+            return hockeyApi
+                .getTeams()
+                .then(res => {
+                    commit('setTeamList', res.data)
+                })
+        },
+        storeTeam({ commit }, teamPayload) {
+            return hockeyApi
+                .storeTeam(teamPayload)
+                .then(res => {
+                    commit('storeTeam', res.data)
+                })
+        },
+        clearTeam({ commit }) {
+            commit('setTeam', {
+                team_name: ''
+            })
+        },
         initializePlayers({ dispatch }, params = {}) {
             dispatch('setPlayerList', params)
         },
         initializeSets({ dispatch }) {
             dispatch('setSetList')
+        },
+        initializeTeams({ dispatch }) {
+            dispatch('setTeamList')
         },
     }
 }

--- a/src/views/hockey/teams/AddTeam.vue
+++ b/src/views/hockey/teams/AddTeam.vue
@@ -1,0 +1,25 @@
+<template>
+    <div>
+        <div>
+            <input v-model="team.team_name"/> Name
+            <button @click="submit">Add</button>
+        </div>
+    </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+
+export default {
+
+    computed: {
+        ...mapGetters('hockey', ['team']),
+    },
+    methods: {
+        ...mapActions('hockey', ['storeTeam', 'clearTeam']),
+        submit() {
+            this.storeTeam(this.team).then(this.clearTeam())
+        }
+    }
+}
+</script>


### PR DESCRIPTION
## What does this PR do?
This PR adds create and read for teams. It also adds a functional add team form on the team view.
## Related PRs

## Testing Steps
- navigate to http://localhost:8080/hockey/teams/addTeams
- fill out form and click add
- see that form is cleared and verify team was added in your db by hitting http://localhost:8000/api/teams in postman
## Checklist before merging
- [ ] If its a core feature, I have added through test.
- [ ] Do we need to implement analytics? 
- [ ] Will this be part of a product update? If yes, please write one phrase about this update
